### PR TITLE
Implement quotation history

### DIFF
--- a/README_API_COTIZACIONES.md
+++ b/README_API_COTIZACIONES.md
@@ -57,9 +57,6 @@
     "total": 1612990
   }
 }
-```
-
----
 
 ### Listar cotizaciones con filtros
 **GET** `/api/cotizaciones`
@@ -246,6 +243,27 @@ GET /api/cotizaciones/2
     "producto_id": 8,
     "cantidad": 2,
     "precio_unitario": 450000
+  }
+]
+```
+
+### Historial de una cotización
+**GET** `/api/cotizaciones/{id}/historial`
+
+Devuelve los eventos asociados a la cotización.
+
+**Ejemplo:**
+```
+GET /api/cotizaciones/2/historial
+```
+
+**Respuesta:**
+```json
+[
+  {
+    "id": 1,
+    "fecha": "2024-06-19T14:30:00-04:00",
+    "accion": "Creada"
   }
 ]
 ```

--- a/api/controllers/cotizacion_controller.go
+++ b/api/controllers/cotizacion_controller.go
@@ -203,6 +203,14 @@ func CreateCotizacion(db *gorm.DB, cotizacion *models.Cotizacion) error {
 		return err
 	}
 
+	// Registrar en historial
+	h := models.HistorialCotizacion{
+		CotizacionID: cotizacion.ID,
+		Accion:       "Creada",
+		Fecha:        time.Now(),
+	}
+	_ = CreateHistorial(db, &h)
+
 	return nil
 }
 
@@ -249,6 +257,17 @@ func UpdateEstadoCotizacion(db *gorm.DB, id uint, nuevoEstado string, usuarioID 
 	if err != nil {
 		return dtos.CotizacionResponse{}, errors.New("cotización actualizada, pero error al recargar para la respuesta: " + err.Error())
 	}
+
+	// Registrar historial
+	detalle := "Estado: " + nuevoEstado
+	hist := models.HistorialCotizacion{
+		CotizacionID: id,
+		Accion:       "Cambio de estado",
+		UsuarioID:    usuarioID,
+		Fecha:        time.Now(),
+		Detalles:     &detalle,
+	}
+	_ = CreateHistorial(db, &hist)
 
 	return mappers.MapCotizacionToDTO(updatedCotizacionModel), nil
 }
@@ -330,5 +349,33 @@ func UpdateCotizacionDetalle(db *gorm.DB, cotizacionID uint, nuevoDetalle []mode
 		return dtos.CotizacionResponse{}, err
 	}
 
+	// Registrar historial
+	desc := "Actualización de detalles"
+	h := models.HistorialCotizacion{
+		CotizacionID: cotizacionID,
+		Accion:       "Modificación de detalle",
+		Fecha:        time.Now(),
+		Detalles:     &desc,
+	}
+	_ = CreateHistorial(db, &h)
+
 	return mappers.MapCotizacionToDTO(updatedCotizacionModel), nil
+}
+
+// CreateHistorial registra un nuevo evento en el historial de una cotizacion.
+func CreateHistorial(db *gorm.DB, historial *models.HistorialCotizacion) error {
+	return db.Create(historial).Error
+}
+
+// GetHistorialByCotizacionID devuelve el historial de una cotizacion especifica.
+func GetHistorialByCotizacionID(db *gorm.DB, cotizacionID uint) ([]dtos.HistorialCotizacionResponse, error) {
+	var registros []models.HistorialCotizacion
+	if err := db.Preload("Usuario").Where("cotizacion_id = ?", cotizacionID).Order("fecha asc").Find(&registros).Error; err != nil {
+		return nil, err
+	}
+	res := make([]dtos.HistorialCotizacionResponse, len(registros))
+	for i, h := range registros {
+		res[i] = mappers.MapHistorialCotizacionToDTO(h)
+	}
+	return res, nil
 }

--- a/api/database/db.go
+++ b/api/database/db.go
@@ -53,7 +53,11 @@ func InitDB() {
 
 	log.Println("Conexión a la base de datos establecida exitosamente.")
 
-	migrationErr := DB.AutoMigrate(&models.Usuario{}, &models.Cliente{})
+	migrationErr := DB.AutoMigrate(
+		&models.Usuario{},
+		&models.Cliente{},
+		&models.HistorialCotizacion{},
+	)
 
 	if migrationErr != nil {
 		log.Fatalf("Fallo la automigración de la base de datos: %v", err)

--- a/api/dtos/historial_cotizacion_dtos.go
+++ b/api/dtos/historial_cotizacion_dtos.go
@@ -1,0 +1,12 @@
+package dtos
+
+import "time"
+
+// HistorialCotizacionResponse representa un registro del historial de una cotizacion.
+type HistorialCotizacionResponse struct {
+	ID       uint                      `json:"id"`
+	Fecha    time.Time                 `json:"fecha"`
+	Accion   string                    `json:"accion"`
+	Usuario  *UsuarioAprobadorResponse `json:"usuario,omitempty"`
+	Detalles *string                   `json:"detalles,omitempty"`
+}

--- a/api/handlers/cotizacion_handler.go
+++ b/api/handlers/cotizacion_handler.go
@@ -163,3 +163,23 @@ func UpdateCotizacionDetalleHandler(db *gorm.DB) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{"message": "Detalles de cotización actualizados con éxito", "cotizacion": updatedCotizacionDTO})
 	}
 }
+
+// GetHistorialCotizacionHandler maneja la obtención del historial de una cotizacion.
+func GetHistorialCotizacionHandler(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		idStr := c.Param("id")
+		id, err := strconv.ParseUint(idStr, 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ID inválido"})
+			return
+		}
+
+		historial, err := controllers.GetHistorialByCotizacionID(db, uint(id))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, historial)
+	}
+}

--- a/api/mappers/cotizacion_mapper.go
+++ b/api/mappers/cotizacion_mapper.go
@@ -79,6 +79,22 @@ func MapDetalleCotizacionToDTO(detalle models.DetalleCotizacion) dtos.DetalleCot
 	}
 }
 
+// MapHistorialCotizacionToDTO convierte un modelo HistorialCotizacion en su DTO correspondiente.
+func MapHistorialCotizacionToDTO(h models.HistorialCotizacion) dtos.HistorialCotizacionResponse {
+	var usuarioDTO *dtos.UsuarioAprobadorResponse
+	if h.Usuario != nil {
+		u := *h.Usuario
+		usuarioDTO = MapUsuarioToAprobadorDTO(u)
+	}
+	return dtos.HistorialCotizacionResponse{
+		ID:       h.ID,
+		Fecha:    h.Fecha,
+		Accion:   h.Accion,
+		Usuario:  usuarioDTO,
+		Detalles: h.Detalles,
+	}
+}
+
 // Helper para mapear models.DetalleCotizacion a dtos.ProductoSimplificadoResponse
 func MapDetalleToProductoSimplificado(detalle models.DetalleCotizacion) dtos.ProductoSimplificadoResponse {
 	return dtos.ProductoSimplificadoResponse{

--- a/api/models/historial_cotizacion_model.go
+++ b/api/models/historial_cotizacion_model.go
@@ -1,0 +1,19 @@
+package models
+
+import "time"
+
+// HistorialCotizacion representa los cambios relevantes de una cotizacion.
+type HistorialCotizacion struct {
+	ID           uint       `gorm:"primaryKey"`
+	CotizacionID uint       `gorm:"column:cotizacion_id;not null"`
+	Cotizacion   Cotizacion `gorm:"foreignKey:CotizacionID"`
+	Accion       string     `gorm:"column:accion;type:VARCHAR(100);not null"`
+	UsuarioID    *uint      `gorm:"column:usuario_id"`
+	Usuario      *Usuario   `gorm:"foreignKey:UsuarioID"`
+	Fecha        time.Time  `gorm:"column:fecha;autoCreateTime"`
+	Detalles     *string    `gorm:"column:detalles;type:TEXT"`
+}
+
+func (HistorialCotizacion) TableName() string {
+	return "historial_cotizaciones"
+}

--- a/api/routes/setup_routes.go
+++ b/api/routes/setup_routes.go
@@ -24,6 +24,7 @@ func SetupRoutes(router *gin.Engine, db *gorm.DB) {
 		api.GET("/cotizaciones/:id", handlers.GetCotizacionByIDHandler(db))
 		api.PATCH("/cotizaciones/:id/estado", handlers.UpdateEstadoCotizacionHandler(db))
 		api.PATCH("/cotizaciones/:id/detalles", handlers.UpdateCotizacionDetalleHandler(db))
+		api.GET("/cotizaciones/:id/historial", handlers.GetHistorialCotizacionHandler(db))
 
 		// !!! IMPORTANTE: Estas rutas necesitan ser refactorizadas en sus handlers
 		// para aceptar 'db' y retornar gin.HandlerFunc, de forma consistente.


### PR DESCRIPTION
## Summary
- implement HistorialCotizacion model and migration
- log creation, status updates and detail changes
- expose new `/cotizaciones/:id/historial` endpoint
- document the history endpoint

## Testing
- `go vet ./...` *(fails: go mod tidy requires network)*
- `go build ./...` *(fails: go mod tidy requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6865bea97e808320a7378d61a8338324