### PR TITLE
Se añadió la API que consume las tiendas de tipo Sucursal

### DIFF
--- a/api/controllers/sucursales_controller.go
+++ b/api/controllers/sucursales_controller.go
@@ -1,0 +1,24 @@
+package controllers
+
+import (
+	"backend-ventas/api/database"
+	"backend-ventas/api/models"
+)
+
+// ListarSucursales devuelve todas las ubicaciones cuyo tipo_id = 2 (sucursales)
+func ListarSucursales() ([]models.Sucursales, error) {
+	var sucursales []models.Sucursales
+	err := database.DB.
+		Where("tipo_id = ?", 2).
+		Find(&sucursales).Error
+	return sucursales, err
+}
+
+// ObtenerSucursalPorID devuelve una sucursal por su id, asegurándose de que sea tipo_id = 2
+func ObtenerSucursalPorID(id int) (models.Sucursales, error) {
+	var sucursal models.Sucursales
+	err := database.DB.
+		Where("id = ? AND tipo_id = ?", id, 2).
+		First(&sucursal).Error
+	return sucursal, err
+}

--- a/api/dtos/sucursales.go
+++ b/api/dtos/sucursales.go
@@ -1,0 +1,11 @@
+package dtos
+
+// UbicacionResponse es lo que devolvemos al cliente para cada sucursal
+type UbicacionResponse struct {
+	ID        int    `json:"id"`
+	Nombre    string `json:"nombre"`
+	Telefono  string `json:"telefono"`
+	Direccion string `json:"direccion"`
+	Comuna    string `json:"comuna"`
+	Ciudad    string `json:"ciudad"`
+}

--- a/api/handlers/sucursales_handler.go
+++ b/api/handlers/sucursales_handler.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"backend-ventas/api/controllers"
+	"backend-ventas/api/dtos"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// ObtenerSucursales construye el handler para GET /sucursales
+func ObtenerSucursales(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		sucursales, err := controllers.ListarSucursales()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Error al obtener sucursales"})
+			return
+		}
+
+		var resp []dtos.UbicacionResponse
+		for _, s := range sucursales {
+			resp = append(resp, dtos.UbicacionResponse{
+				ID:        s.ID,
+				Nombre:    s.Nombre,
+				Telefono:  s.Telefono,
+				Direccion: s.Direccion,
+				Comuna:    s.Comuna,
+				Ciudad:    s.Ciudad,
+			})
+		}
+
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
+// ObtenerSucursal construye el handler para GET /sucursales/:id
+func ObtenerSucursal(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		idParam := c.Param("id")
+		id, err := strconv.Atoi(idParam)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ID de sucursal inválido"})
+			return
+		}
+
+		sucursal, err := controllers.ObtenerSucursalPorID(id)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Sucursal no encontrada"})
+			return
+		}
+
+		resp := dtos.UbicacionResponse{
+			ID:        sucursal.ID,
+			Nombre:    sucursal.Nombre,
+			Telefono:  sucursal.Telefono,
+			Direccion: sucursal.Direccion,
+			Comuna:    sucursal.Comuna,
+			Ciudad:    sucursal.Ciudad,
+		}
+
+		c.JSON(http.StatusOK, resp)
+	}
+}

--- a/api/models/sucursales.go
+++ b/api/models/sucursales.go
@@ -1,0 +1,12 @@
+package models
+
+// Sucursales representa una fila de la tabla de ubicaciones/sucursales
+type Sucursales struct {
+	ID        int    `db:"id" json:"id"`
+	Nombre    string `db:"nombre" json:"nombre"`
+	Telefono  string `db:"telefono" json:"telefono"`
+	TipoID    int    `db:"tipo_id" json:"tipo_id"`
+	Direccion string `db:"direccion" json:"direccion"`
+	Comuna    string `db:"comuna" json:"comuna"`
+	Ciudad    string `db:"ciudad" json:"ciudad"`
+}

--- a/api/routes/setup_routes.go
+++ b/api/routes/setup_routes.go
@@ -22,6 +22,7 @@ func SetupRoutes(router *gin.Engine) {
 			"status":  "running",
 			"endpoints": gin.H{
 				"cotizaciones": "/api/cotizaciones",
+				"sucursales":   "/api/sucursales",
 				"health":       "/health",
 			},
 		})
@@ -36,6 +37,7 @@ func SetupRoutes(router *gin.Engine) {
 
 	// Configurar rutas de cotizaciones
 	CotizacionRoutes(router)
+	SucursalesRoutes(router)
 
 	// Aquí agregar más grupos de rutas en el futuro:
 	// - ProductoRoutes(router)

--- a/api/routes/sucursales_routes.go
+++ b/api/routes/sucursales_routes.go
@@ -1,0 +1,17 @@
+package routes
+
+import (
+	"backend-ventas/api/database"
+	"backend-ventas/api/handlers"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterUbicacionRoutes añade los endpoints de sucursales al router
+func SucursalesRoutes(r *gin.Engine) {
+	sucursales := r.Group("/api/sucursales")
+	{
+		sucursales.GET("", handlers.ObtenerSucursales(database.DB))
+		sucursales.GET("/:id", handlers.ObtenerSucursal(database.DB))
+	}
+}


### PR DESCRIPTION
## 🚀 Objetivo

Añadir el **endpoint de Sucursales** para que el vendedor reciba únicamente las ubicaciones de tipo **Tienda** desde el backend.

---

## 📦 Cambios incluidos

<details>
<summary><strong>Nuevos archivos</strong></summary>

| Ruta | Descripción |
|------|-------------|
| `api/controller/sucursales_controller.go` | Controladores para obtener solo las sucursales que son *Tienda*. |
| `api/dtos/sucursales.go` | DTO con la estructura de respuesta esperada. |
| `api/handlers/sucursales_handler.go` | Handler principal para la ruta. |
| `api/routes/sucursales_routes.go` | Rutas de los endpoints de sucursales relevantes para el vendedor. |
</details>

<details>
<summary><strong>Archivos modificados</strong></summary>

| Ruta | Motivo |
|------|--------|
| `api/routes/setup_routes.go` | Se registró `SucursalesRoutes(router)`. |
</details>

